### PR TITLE
handle case for when there are no files in readdir

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -314,6 +314,12 @@ module.exports = {
             return not_a_dir(err);
           }
           return sftp.readdir(handle, function(err, files) {
+            if (err) {
+              return callback(err);
+            }
+            if (!files) {
+              files = [];
+            }
             return sftp.close(handle, function(err) {
               var file;
               if (err) {


### PR DESCRIPTION
Fixing this error:

```

TypeError: Cannot read property 'length' of undefined
    at /var/app/current/node_modules/ssh2-fs/lib/index.js:326:40
    at /var/app/current/node_modules/ssh2-fs/lib/index.js:331:17
    at SFTPStream._transform (/var/app/current/node_modules/ssh2-streams/lib/sftp.js:382:17)
    at SFTPStream.Transform._read (_stream_transform.js:167:10)
    at SFTPStream._read (/var/app/current/node_modules/ssh2-streams/lib/sftp.js:181:15)
    at SFTPStream.Transform._write (_stream_transform.js:155:12)
    at doWrite (_stream_writable.js:333:12)
    at writeOrBuffer (_stream_writable.js:319:5)
    at SFTPStream.Writable.write (_stream_writable.js:246:11)
    at Channel.ondata (_stream_readable.js:555:20)
error: Forever detected script exited with code: 1
error: Script restart attempt #7
/var/app/current/node_modules/ssh2-fs/lib/index.js:326
                for (i = 0, len = files.length; i < len; i++) {
                                       ^
```